### PR TITLE
Atomic thread count update

### DIFF
--- a/network_test.c
+++ b/network_test.c
@@ -252,7 +252,9 @@ int main( int argc, char *argv[])
     }
 
     
-    printf("time: %f \n\n\n", time_spent);
+    printf("time: %f \n", time_spent);
+    printf("max simultaneous threads: %d\n", thread_simul_cnt);
+    printf("\n\n");
 
     destroy_network(nnet);
     free(feature_range);

--- a/split.c
+++ b/split.c
@@ -20,6 +20,7 @@ int NEED_FOR_ONE_RUN = 0;
 int input_depth = 0;
 int adv_found = 0;
 int count = 0;
+int thread_simul_cnt = 0;
 int thread_tot_cnt  = 0;
 int smear_cnt = 0;
 
@@ -956,6 +957,9 @@ int split_interval(struct NNet *nnet, struct Interval *input,\
 
         count++;
         thread_tot_cnt++;
+        if (count > thread_simul_cnt) {
+            thread_simul_cnt = count;
+        }
 
     pthread_mutex_unlock(&lock);
 
@@ -967,6 +971,9 @@ int split_interval(struct NNet *nnet, struct Interval *input,\
 
         count++;
         thread_tot_cnt++;
+        if (count > thread_simul_cnt) {
+            thread_simul_cnt = count;
+        }
 
     pthread_mutex_unlock(&lock);
 

--- a/split.c
+++ b/split.c
@@ -932,7 +932,13 @@ int split_interval(struct NNet *nnet, struct Interval *input,\
     pthread_mutex_lock(&lock);
 
     if ((depth <= avg_depth - MIN_DEPTH_PER_THREAD) &&\
-            (count<=MAX_THREAD)) {
+            (count+2 <= MAX_THREAD)) {
+
+        count += 2;
+        thread_tot_cnt += 2;
+        if (count > thread_simul_cnt) {
+            thread_simul_cnt = count;
+        }
 
     pthread_mutex_unlock(&lock);
 
@@ -953,29 +959,9 @@ int split_interval(struct NNet *nnet, struct Interval *input,\
 
         pthread_create(&workers1, NULL, direct_run_check_thread, &args1);
 
-    pthread_mutex_lock(&lock);
-
-        count++;
-        thread_tot_cnt++;
-        if (count > thread_simul_cnt) {
-            thread_simul_cnt = count;
-        }
-
-    pthread_mutex_unlock(&lock);
-
         //printf ( "pid1: %ld start %d \n", syscall(SYS_gettid), count);
 
         pthread_create(&workers2, NULL, direct_run_check_thread, &args2);
-
-    pthread_mutex_lock(&lock);
-
-        count++;
-        thread_tot_cnt++;
-        if (count > thread_simul_cnt) {
-            thread_simul_cnt = count;
-        }
-
-    pthread_mutex_unlock(&lock);
 
         //printf ( "pid2: %ld start %d \n", syscall(SYS_gettid), count);
 

--- a/split.h
+++ b/split.h
@@ -57,6 +57,9 @@ pthread_mutex_t lock;
 /* Active threads number */
 extern int count;
 
+/* Max simultaneous threads */
+extern int thread_simul_cnt;
+
 
 /*
  * Define the argument structure of main function


### PR DESCRIPTION
The current master version of ReluVal can sometimes create more than `MAX_THREAD` threads. This can be seen by applying only the first commit in this pull request (track max simultaneous threads). Max simultaneous thread counts greater than 56 are sometimes reported.

This happens for two reasons:
1. It doesn't atomically check and update count - instead, it acquires a lock, checks `count` (effectively entering a "guarded block"), releases the lock, acquires it again, and then increases `count`. While the lock is released, any number of other active threads can also check `count` and enter the guarded block, because they have no way of knowing that another thread has already done so (or, indeed, how many other threads have already passed the check but not yet updated `count`). This is fixed by releasing the lock only after updating `count`.
2. The guard itself is `count <= MAX_THREAD` when it should be `count+2 <= MAX_THREAD`, accounting for the two extra threads that will be created.

Both issues are fixed by this pull request. In addition, the max simultaneous thread count is now reported. This doesn't seem to affect timings, so I've left it in.

An added benefit of this pull request is that it reduces the amount of locking, potentially reducing contention and making the program more efficient overall.